### PR TITLE
Create directory for LDIF files

### DIFF
--- a/Dockerfile.example
+++ b/Dockerfile.example
@@ -102,6 +102,9 @@ RUN sed -i 's/ 101/ 0/' /usr/sbin/policy-rc.d \
   && rm -rf /var/lib/apt/lists/* \
   && sed -i 's/ 0/ 101/' /usr/sbin/policy-rc.d
 
+# Create directory for LDIF files
+RUN mkdir ldifs
+
 # Process initial CSV
 RUN if [ -e mail_users.csv ]; \
     then \

--- a/Dockerfile.example
+++ b/Dockerfile.example
@@ -102,8 +102,8 @@ RUN sed -i 's/ 101/ 0/' /usr/sbin/policy-rc.d \
   && rm -rf /var/lib/apt/lists/* \
   && sed -i 's/ 0/ 101/' /usr/sbin/policy-rc.d
 
-# Create directory for LDIF files
-RUN mkdir ldifs
+# Create directory for LDIF files if it does not exist already
+RUN mkdir -p ldifs
 
 # Process initial CSV
 RUN if [ -e mail_users.csv ]; \


### PR DESCRIPTION
Without creating the directory the following `cp` and `mv` command to that directory will fail.
